### PR TITLE
Adding VersionStream for istio-pilot-agent-1.23

### DIFF
--- a/istio-pilot-agent-1.23.yaml
+++ b/istio-pilot-agent-1.23.yaml
@@ -1,0 +1,75 @@
+package:
+  name: istio-pilot-agent-1.23
+  version: 1.23.0
+  epoch: 0
+  description: Nanny binary for Istio Envoy
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - istio-pilot-agent=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 2ed399ccdbf4bc6394d7350cd384e6b0424f70f2
+
+  - uses: go/bump
+    with:
+      deps: github.com/docker/docker@v26.1.5
+
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+      # istio default ldflags: https://github.com/istio/istio/blob/master/Makefile.core.mk#L210
+      # Extracted from https://github.com/istio/istio/blob/4358b84b911a80ba09ef36ac00ad85535a77e7ca/common/scripts/report_build_info.sh#L41-L48
+      # Use this instead for buildStatus once our pipeline stops dirtying the git tree: "$(if git diff-index --quiet HEAD --; then echo "Clean"; else echo "Modified"; fi)"
+      ldflags: |
+        -extldflags -s -w
+        -X istio.io/istio/pkg/version.buildVersion=${{package.version}}
+        -X istio.io/istio/pkg/version.buildGitRevision=$(git rev-parse HEAD)
+        -X istio.io/istio/pkg/version.buildTag=$(git describe --tags --always)
+        -X istio.io/istio/pkg/version.buildStatus="Clean"
+      # istio default agent tags: https://github.com/istio/istio/blob/master/Makefile.core.mk#L239
+      tags: "agent,disable_pgv"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/var/lib/istio/envoy
+      cp ./tools/packaging/common/envoy_bootstrap.json \
+        ${{targets.destdir}}/var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+      cp ./tools/packaging/common/gcp_envoy_bootstrap.json \
+        ${{targets.destdir}}/var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # link /usr/local/bin/pilot-agent -> /usr/bin/pilot-agent to match
+          # what the Istio Helm charts may expect.
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/pilot-agent ${{targets.subpkgdir}}/usr/local/bin/pilot-agent
+    dependencies:
+      provides:
+        - istio-pilot-agent-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - "-rc"
+    - "-beta"
+  github:
+    identifier: istio/istio
+    tag-filter-prefix: 1.23.
+    use-tag: true


### PR DESCRIPTION
Sample PR: https://github.com/wlynch/wolfi-os/pull/7

I did encounter some `object not found` errors when running locally. https://github.com/chainguard-dev/infra-images/blob/7d92523d7ddeae55c4b920502cf837123e460766/insights/producers/pkg/git/workspace.go#L180 calls this out as a known error - needs more investigation (my guess is this has to do with shallow clones?)